### PR TITLE
feat: Update handling destination address `0x0`

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -13,7 +13,7 @@ const (
 var (
 	majorVer  uint64 = 1
 	minorVer  uint64 = 3
-	patchVer  uint64 = 18
+	patchVer  uint64 = 19
 	commitVer uint64 = 0
 
 	// it is changed using ldflags.

--- a/ctrlers/types/trx_ctx.go
+++ b/ctrlers/types/trx_ctx.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	rtypes "github.com/rigochain/rigo-go/types"
 	bytes2 "github.com/rigochain/rigo-go/types/bytes"
 	"github.com/rigochain/rigo-go/types/xerrors"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
@@ -67,9 +66,10 @@ func NewTrxContext(txbz []byte, height, btime int64, exec bool, cbfns ...NewTrxC
 	if txctx.Sender == nil {
 		return nil, xerrors.ErrNotFoundAccount.Wrapf("address: %v", tx.From)
 	}
-	if !rtypes.IsZeroAddress(tx.To) {
-		txctx.Receiver = txctx.AcctHandler.FindOrNewAccount(tx.To, txctx.Exec)
+	// RG-91:  Also find the account object with the destination address 0x0.
+	txctx.Receiver = txctx.AcctHandler.FindOrNewAccount(tx.To, txctx.Exec)
+	if txctx.Receiver == nil {
+		return nil, xerrors.ErrNotFoundAccount.Wrapf("address: %v", tx.To)
 	}
-
 	return txctx, nil
 }


### PR DESCRIPTION
When the destination address is zero address,
find account object with address zero address
and set it to TrxCtx.Receiver.

Related to: #RG-91